### PR TITLE
Improve test coverage for Evidence, Command, and Redactor

### DIFF
--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -23,4 +23,94 @@ class CommandTest < Minitest::Test
     assert_equal "ok", result.stdout
     assert_equal 0, result.status
   end
+
+  def test_capture_raises_command_error_on_failure
+    spec = KamalBackup::CommandSpec.new(argv: [RbConfig.ruby, "-e", "warn 'boom'; exit 1"])
+
+    error = assert_raises(KamalBackup::CommandError) do
+      KamalBackup::Command.capture(spec, redactor: KamalBackup::Redactor.new(env: {}))
+    end
+
+    assert_equal 1, error.status
+    assert_includes error.stderr, "boom"
+    assert_includes error.message, "command failed (1)"
+  end
+
+  def test_capture_raises_command_error_for_missing_binary
+    spec = KamalBackup::CommandSpec.new(argv: ["nonexistent_binary_xyz_12345"])
+
+    error = assert_raises(KamalBackup::CommandError) do
+      KamalBackup::Command.capture(spec, redactor: KamalBackup::Redactor.new(env: {}))
+    end
+
+    assert_equal 127, error.status
+    assert_includes error.message, "command not found"
+  end
+
+  def test_capture_returns_stderr_on_success
+    spec = KamalBackup::CommandSpec.new(argv: [RbConfig.ruby, "-e", "print 'out'; $stderr.print 'err'"])
+
+    result = KamalBackup::Command.capture(spec, redactor: KamalBackup::Redactor.new(env: {}))
+
+    assert_equal "out", result.stdout
+    assert_equal "err", result.stderr
+    assert_equal 0, result.status
+  end
+
+  def test_capture_passes_env_to_command
+    spec = KamalBackup::CommandSpec.new(
+      argv: [RbConfig.ruby, "-e", "print ENV['TEST_KAMAL_VAR']"],
+      env: { "TEST_KAMAL_VAR" => "hello" }
+    )
+
+    result = KamalBackup::Command.capture(spec, redactor: KamalBackup::Redactor.new(env: {}))
+
+    assert_equal "hello", result.stdout
+  end
+
+  def test_capture_passes_stdin_data
+    spec = KamalBackup::CommandSpec.new(argv: [RbConfig.ruby, "-e", "print $stdin.read.upcase"])
+
+    result = KamalBackup::Command.capture(spec, input: "hello", redactor: KamalBackup::Redactor.new(env: {}))
+
+    assert_equal "HELLO", result.stdout
+  end
+
+  def test_capture_redacts_secrets_in_error_message
+    spec = KamalBackup::CommandSpec.new(
+      argv: [RbConfig.ruby, "-e", "warn 'password is supersecret123'; exit 1"],
+      env: {}
+    )
+    redactor = KamalBackup::Redactor.new(env: { "RESTIC_PASSWORD" => "supersecret123" })
+
+    error = assert_raises(KamalBackup::CommandError) do
+      KamalBackup::Command.capture(spec, redactor: redactor)
+    end
+
+    refute_includes error.message, "supersecret123"
+    assert_includes error.message, "[REDACTED]"
+  end
+
+  def test_command_spec_rejects_empty_argv
+    assert_raises(ArgumentError) do
+      KamalBackup::CommandSpec.new(argv: [])
+    end
+  end
+
+  def test_command_spec_strips_nil_env_values
+    spec = KamalBackup::CommandSpec.new(
+      argv: ["echo"],
+      env: { "KEEP" => "value", "DROP" => nil, "EMPTY" => "" }
+    )
+
+    assert_equal({ "KEEP" => "value" }, spec.env)
+  end
+
+  def test_available_returns_true_for_existing_binary
+    assert KamalBackup::Command.available?(RbConfig.ruby.split("/").last)
+  end
+
+  def test_available_returns_false_for_nonexistent_binary
+    refute KamalBackup::Command.available?("nonexistent_binary_xyz_12345")
+  end
 end

--- a/test/evidence_test.rb
+++ b/test/evidence_test.rb
@@ -13,6 +13,17 @@ class EvidenceTest < Minitest::Test
     end
   end
 
+  class ErrorRestic
+    def latest_snapshot(tags:)
+      raise KamalBackup::CommandError.new(
+        "restic failed",
+        command: KamalBackup::CommandSpec.new(argv: ["restic", "snapshots"]),
+        status: 1,
+        stderr: "connection refused"
+      )
+    end
+  end
+
   def test_evidence_includes_the_last_restore_drill
     Dir.mktmpdir do |dir|
       config = KamalBackup::Config.new(env: base_env(
@@ -37,4 +48,151 @@ class EvidenceTest < Minitest::Test
       assert_equal "local", evidence.fetch(:last_restore_drill).fetch("scope")
     end
   end
+
+  def test_evidence_without_drill_or_check_files
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir
+      ))
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: FakeRestic.new,
+        redactor: KamalBackup::Redactor.new(env: {})
+      ).to_h
+
+      assert_equal 1, evidence.fetch(:schema_version)
+      assert_equal "evidence", evidence.fetch(:kind)
+      assert_nil evidence.fetch(:last_restore_drill)
+      assert_nil evidence.fetch(:last_restic_check)
+    end
+  end
+
+  def test_evidence_includes_last_check
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir
+      ))
+      File.write(
+        config.last_check_path,
+        JSON.pretty_generate({ status: "ok", started_at: "2026-04-23T10:00:00Z", finished_at: "2026-04-23T10:01:00Z", output: "no errors" })
+      )
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: FakeRestic.new,
+        redactor: KamalBackup::Redactor.new(env: {})
+      ).to_h
+
+      assert_equal "ok", evidence.fetch(:last_restic_check).fetch("status")
+      assert_equal "no errors", evidence.fetch(:last_restic_check).fetch("output")
+    end
+  end
+
+  def test_evidence_handles_corrupt_check_json
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir
+      ))
+      File.write(config.last_check_path, "not valid json{{{")
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: FakeRestic.new,
+        redactor: KamalBackup::Redactor.new(env: {})
+      ).to_h
+
+      check = evidence.fetch(:last_restic_check)
+      assert check.key?("error") || check.key?(:error)
+    end
+  end
+
+  def test_evidence_handles_corrupt_drill_json
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir
+      ))
+      File.write(config.last_restore_drill_path, "broken json!")
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: FakeRestic.new,
+        redactor: KamalBackup::Redactor.new(env: {})
+      ).to_h
+
+      drill = evidence.fetch(:last_restore_drill)
+      assert drill.key?("error") || drill.key?(:error)
+    end
+  end
+
+  def test_evidence_snapshot_error_returns_error_hash
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir
+      ))
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: ErrorRestic.new,
+        redactor: KamalBackup::Redactor.new(env: {})
+      ).to_h
+
+      assert evidence.fetch(:latest_database_backup).key?(:error)
+      assert evidence.fetch(:latest_file_backup).key?(:error)
+    end
+  end
+
+  def test_evidence_includes_snapshot_summaries
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir
+      ))
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: FakeRestic.new,
+        redactor: KamalBackup::Redactor.new(env: {})
+      ).to_h
+
+      db_backup = evidence.fetch(:latest_database_backup)
+      assert_equal "db123", db_backup.fetch(:id)
+      assert_equal "2026-04-23T11:00:00Z", db_backup.fetch(:time)
+
+      file_backup = evidence.fetch(:latest_file_backup)
+      assert_equal "files123", file_backup.fetch(:id)
+    end
+  end
+
+  def test_evidence_redacts_restic_repository
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(env: base_env(
+        "DATABASE_ADAPTER" => "sqlite",
+        "BACKUP_PATHS" => "/tmp/storage",
+        "KAMAL_BACKUP_STATE_DIR" => dir,
+        "RESTIC_REPOSITORY" => "s3:https://user:secret@s3.example.com/bucket"
+      ))
+
+      evidence = KamalBackup::Evidence.new(
+        config,
+        restic: FakeRestic.new,
+        redactor: KamalBackup::Redactor.new(env: config.env)
+      ).to_h
+
+      refute_includes evidence.fetch(:restic_repository), "secret"
+      assert_includes evidence.fetch(:restic_repository), "[REDACTED]"
+    end
+  end
+
 end

--- a/test/redactor_test.rb
+++ b/test/redactor_test.rb
@@ -40,4 +40,77 @@ class RedactorTest < Minitest::Test
     assert_equal "[REDACTED]", redacted["AWS_ACCESS_KEY_ID"]
     assert_equal "demo", redacted["APP_NAME"]
   end
+
+  def test_ignores_short_secret_values
+    redactor = KamalBackup::Redactor.new(env: { "RESTIC_PASSWORD" => "abc" })
+
+    assert_equal "value is abc", redactor.redact_string("value is abc")
+  end
+
+  def test_redacts_explicit_secret_values
+    redactor = KamalBackup::Redactor.new(secret_values: ["my-token-123"])
+
+    assert_equal "token: [REDACTED]", redactor.redact_string("token: my-token-123")
+  end
+
+  def test_redact_string_handles_nil_coercion
+    redactor = KamalBackup::Redactor.new(env: {})
+
+    assert_equal "", redactor.redact_string(nil)
+  end
+
+  def test_redact_value_returns_nil_for_nil
+    redactor = KamalBackup::Redactor.new(env: {})
+
+    assert_nil redactor.redact_value("APP_NAME", nil)
+  end
+
+  def test_redact_value_redacts_password_keys_regardless_of_case
+    redactor = KamalBackup::Redactor.new(env: {})
+
+    assert_equal "[REDACTED]", redactor.redact_value("DB_PASSWORD", "visible")
+    assert_equal "[REDACTED]", redactor.redact_value("db_password", "visible")
+    assert_equal "[REDACTED]", redactor.redact_value("MySecret", "visible")
+    assert_equal "[REDACTED]", redactor.redact_value("API_TOKEN", "visible")
+    assert_equal "[REDACTED]", redactor.redact_value("aws_secret_access_key", "visible")
+  end
+
+  def test_redact_value_passes_through_non_secret_keys
+    redactor = KamalBackup::Redactor.new(env: {})
+
+    assert_equal "demo", redactor.redact_value("APP_NAME", "demo")
+    assert_equal "postgres", redactor.redact_value("DATABASE_ADAPTER", "postgres")
+  end
+
+  def test_redacts_multiple_secrets_in_one_string
+    redactor = KamalBackup::Redactor.new(env: {
+      "RESTIC_PASSWORD" => "restic-pass",
+      "AWS_SECRET_ACCESS_KEY" => "aws-secret-key"
+    })
+
+    result = redactor.redact_string("restic: restic-pass, aws: aws-secret-key")
+
+    refute_includes result, "restic-pass"
+    refute_includes result, "aws-secret-key"
+    assert_includes result, "[REDACTED]"
+  end
+
+  def test_redacts_url_with_user_only_no_password
+    redactor = KamalBackup::Redactor.new(env: {})
+
+    value = redactor.redact_string("postgres://admin@db.example/app")
+
+    assert_equal "postgres://[REDACTED]@db.example/app", value
+  end
+
+  def test_redacts_multiple_query_params
+    redactor = KamalBackup::Redactor.new(env: {})
+
+    value = redactor.redact_string("https://host/path?token=abc123&password=xyz&name=app")
+
+    assert_includes value, "token=[REDACTED]"
+    assert_includes value, "password=[REDACTED]"
+    assert_includes value, "name=app"
+  end
+
 end


### PR DESCRIPTION
## Summary

- **Evidence**: +7 tests covering missing state files, corrupt JSON graceful handling, restic connection errors, snapshot summaries, and credential redaction in repository URLs
- **Command**: +10 tests covering failure exit codes, missing binary detection (status 127), stderr capture, env forwarding, stdin input, secret redaction in error messages, empty argv validation, and nil env filtering
- **Redactor**: +9 tests covering short secret threshold (<4 chars), explicit secret_values parameter, nil input coercion, case-insensitive key pattern matching, multiple secrets in one string, user-only URLs, and multiple query parameter redaction

## Test plan

- [x] All 26 new tests pass locally
- [x] Full test suite passes (2 pre-existing macOS `/var` symlink failures in `cli_test.rb` unrelated to this change)
- [x] No implementation changes — tests only