### PR TITLE
Bundle PostgreSQL 18 client so backups work against pg18 servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
     mariadb-client \
-    postgresql-client \
+    postgresql-client-common \
     restic \
     sqlite3 \
     tini \
+  && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+  && apt-get install -y --no-install-recommends postgresql-client-18 \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Problem

Deployments against a PostgreSQL 18 server currently fail on first backup:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 18.x; pg_dump version: 17.x
```

The current image installs Debian's `postgresql-client` package, which resolves to pg17 on Debian trixie. `pg_dump` refuses to dump from a newer server, so backups never run.

## Fix

Install `postgresql-client-18` from the official PostgreSQL apt repository (PGDG) using the setup script shipped in `postgresql-client-common`. The script comes from Debian and is the [install path documented on postgresql.org](https://www.postgresql.org/download/linux/debian/).

`postgresql-client-common` is chosen over `postgresql-common` because it ships the same setup script and PGDG GPG key without pulling in cluster-management tooling we don't need.

Debian stable doesn't update package majors mid-release, so pinning via PGDG is the only path until the next Debian stable (forky) is released (~2027).


## No tests?

I considered a CI step that builds a small database and dumps it. But that just makes an implicit test explicit - if `postgresql-client-18` fails to install, `docker build` fails and the existing `image` job already catches it.

If the build steps succeeds, it's kind of a test in itself. But happy to re-consider if you think it's warranted :+1:

## Manual confirmation

I did manually test this by using the `Dockerfile` from this branch in my local kamal app to verify manual 18.3 dumps works.