### PR TITLE
Fix restore and drill for database-only backups

### DIFF
--- a/lib/kamal_backup/app.rb
+++ b/lib/kamal_backup/app.rb
@@ -374,9 +374,11 @@ module KamalBackup
     end
 
     def perform_replacement_file_restore(snapshot, production_source:)
+      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'], required: false)
+      return nil unless resolved_snapshot
+
       source_paths = production_source ? config.backup_paths : config.local_restore_source_paths
       target_paths = config.backup_paths
-      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'])
       Dir.mktmpdir('kamal-backup-restore-') do |stage_dir|
         restic.restore_snapshot(resolved_snapshot, stage_dir)
         replace_target_paths(stage_dir, source_paths: source_paths, target_paths: target_paths)
@@ -411,7 +413,9 @@ module KamalBackup
     end
 
     def perform_file_restore(snapshot, target:)
-      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'])
+      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'], required: false)
+      return nil unless resolved_snapshot
+
       validated_target = config.validate_file_restore_target(target)
       restic.restore_snapshot(resolved_snapshot, validated_target)
 
@@ -471,11 +475,17 @@ module KamalBackup
                      end
     end
 
-    def resolve_snapshot(argument, tags:)
+    # Database-only configs never create a type:files snapshot, so file restores
+    # resolve with required: false and skip when nothing was backed up.
+    def resolve_snapshot(argument, tags:, required: true)
       if argument == 'latest'
         snapshot = restic.latest_snapshot(tags: tags)
 
-        raise ConfigurationError, "no restic snapshot found for #{tags.join(', ')}" unless snapshot
+        if snapshot.nil?
+          raise ConfigurationError, "no restic snapshot found for #{tags.join(', ')}" if required
+
+          return nil
+        end
 
         snapshot['short_id'] || snapshot['id']
       else

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -54,7 +54,7 @@ class AppTest < Minitest::Test
 
       if tags.include?('type:database')
         { 'short_id' => @database_snapshot, 'time' => snapshot_time }
-      else
+      elsif @files_snapshot
         { 'short_id' => @files_snapshot, 'time' => snapshot_time }
       end
     end
@@ -484,6 +484,130 @@ class AppTest < Minitest::Test
       assert_equal 1, database.current_restore_calls.size
       assert_equal 'hello from production backup', File.read(File.join(files, 'hello.txt'))
       refute File.exist?(old_file)
+    end
+  end
+
+  def test_restore_to_local_machine_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_development.sqlite3')
+      files = File.join(dir, 'storage')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.restore_to_local_machine('latest')
+
+      assert_equal 1, database.current_restore_calls.size
+      assert_equal 'latest-database-snapshot', database.current_restore_calls.first.fetch(:snapshot)
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
+      assert_equal 'restore_result', result.fetch(:kind)
+    end
+  end
+
+  def test_restore_to_production_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_production.sqlite3')
+      files = File.join(dir, 'storage')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.restore_to_production('latest')
+
+      assert_equal 1, database.current_restore_calls.size
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
+      assert_equal 'production', result.fetch(:scope)
+    end
+  end
+
+  def test_drill_on_local_machine_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_development.sqlite3')
+      files = File.join(dir, 'storage')
+      state = File.join(dir, 'state')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files,
+          'KAMAL_BACKUP_STATE_DIR' => state
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.drill_on_local_machine('latest')
+
+      assert_equal 'ok', result.fetch(:status)
+      assert_equal 1, database.current_restore_calls.size
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
+    end
+  end
+
+  def test_drill_on_production_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      target = File.join(dir, 'restored-files')
+      state = File.join(dir, 'state')
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'postgres')
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'postgres',
+          'DATABASE_URL' => 'postgres://app@db/app_production',
+          'KAMAL_BACKUP_STATE_DIR' => state
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.drill_on_production(
+        'latest',
+        database_name: 'app_restore_20260711',
+        file_target: target
+      )
+
+      assert_equal 'ok', result.fetch(:status)
+      assert_equal 1, database.scratch_restore_calls.size
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
     end
   end
 


### PR DESCRIPTION
## Problem

kamal-backup happily creates database-only backups — a config with `databases:` and no
`paths:` — since the backup side handles empty paths gracefully (`Restic#backup_paths`
is a no-op, so no `type:files` snapshot is created). But every restore entry point
(`restore local`, `restore production`, `drill local`, `drill production`) resolves a
`type:files` snapshot unconditionally and raises when none exists:

```
ConfigurationError: no restic snapshot found for type:files
```

The database restore itself succeeds (it runs first), but the command then fails on the
file step. So a backup the tool made itself cannot be cleanly restored by the same tool,
and `drill local` always records `status: failed` for database-only setups.

## Reproduction

1. A config with `databases:` and no `paths:` (our case: Rails on Kamal with Active
   Storage in S3, so there is nothing file-backed to snapshot).
2. `kamal-backup backup --force` → succeeds; the repo has only `type:database` snapshots
   (verified: `restic snapshots --tag type:files` → `[]`).
3. `kamal-backup restore local` (or `drill local`) →
   `ConfigurationError: no restic snapshot found for type:files`.

## Fix

Resolve the files snapshot as optional in the file-restore steps and skip them when none
exists, mirroring how the backup side handles empty paths:

- `resolve_snapshot` gains a `required:` keyword and returns `nil` instead of raising
  when `required: false` and no snapshot matches.
- `perform_replacement_file_restore` and `perform_file_restore` resolve `type:files`
  with `required: false` and return early when there is nothing to restore. The
  restore/drill result reports `"files": null` in that case.

Restores with a files snapshot present are unchanged, as is passing an explicit
snapshot id (it is forwarded to restic as before).

## Tests

Added a case per entry point: repo has `type:database` snapshots but no `type:files`
snapshot → the database is restored, no file restore is attempted, `result[:files]` is
`nil`, and drills finish with `status: ok`. `FakeRestic` now returns `nil` for the
latest files snapshot when configured with none, matching real behaviour. Existing tests
cover the files-present path unchanged.
