### PR TITLE
Preserve SQLite databases during file restores

### DIFF
--- a/lib/kamal_backup/app.rb
+++ b/lib/kamal_backup/app.rb
@@ -58,8 +58,8 @@ module KamalBackup
 
       build_restore_result('local', snapshot) do |result|
         databases.each { |adapter| validate_local_machine_database_target(adapter) }
-        result[:databases] = perform_database_restores_to_current(snapshot)
         result[:files] = perform_replacement_file_restore(snapshot, production_source: false)
+        result[:databases] = perform_database_restores_to_current(snapshot)
       end
     end
 
@@ -67,8 +67,8 @@ module KamalBackup
       validate_production_restore
 
       build_restore_result('production', snapshot) do |result|
-        result[:databases] = perform_database_restores_to_current(snapshot)
         result[:files] = perform_replacement_file_restore(snapshot, production_source: true)
+        result[:databases] = perform_database_restores_to_current(snapshot)
       end
     end
 

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -437,7 +437,7 @@ class AppTest < Minitest::Test
 
       result = app.restore_to_local_machine('latest')
 
-      assert_equal [['type:database', 'database:app', 'adapter:sqlite'], ['type:files']], restic.latest_snapshot_calls
+      assert_equal [['type:files'], ['type:database', 'database:app', 'adapter:sqlite']], restic.latest_snapshot_calls
       assert_equal [{ snapshot: 'latest-database-snapshot', adapter: 'sqlite', database_name: 'app' }],
                    restic.database_file_calls
       assert_equal 1, database.current_restore_calls.size
@@ -484,6 +484,72 @@ class AppTest < Minitest::Test
       assert_equal 1, database.current_restore_calls.size
       assert_equal 'hello from production backup', File.read(File.join(files, 'hello.txt'))
       refute File.exist?(old_file)
+    end
+  end
+
+  def test_restore_to_production_preserves_sqlite_database_inside_file_backup_path
+    Dir.mktmpdir do |dir|
+      files = File.join(dir, 'storage')
+      db = File.join(files, 'app_production.sqlite3')
+      FileUtils.mkdir_p(files)
+      File.write(db, 'live')
+
+      restic = FakeRestic.new
+      restic.stage_file('latest-files-snapshot', File.join(files, 'hello.txt'), 'restored file')
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      database.define_singleton_method(:restore_to_current) do |_restic, _snapshot, _filename|
+        FileUtils.mkdir_p(File.dirname(db))
+        File.write(db, 'restored database')
+      end
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      app.restore_to_production('latest')
+
+      assert_equal 'restored database', File.read(db)
+      assert_equal 'restored file', File.read(File.join(files, 'hello.txt'))
+    end
+  end
+
+  def test_restore_to_local_machine_preserves_sqlite_database_inside_file_backup_path
+    Dir.mktmpdir do |dir|
+      source_files = '/data/storage'
+      files = File.join(dir, 'storage')
+      db = File.join(files, 'app_development.sqlite3')
+      FileUtils.mkdir_p(files)
+      File.write(db, 'live')
+
+      restic = FakeRestic.new
+      restic.stage_file('latest-files-snapshot', File.join(source_files, 'hello.txt'), 'restored file')
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      database.define_singleton_method(:restore_to_current) do |_restic, _snapshot, _filename|
+        FileUtils.mkdir_p(File.dirname(db))
+        File.write(db, 'restored database')
+      end
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files,
+          'LOCAL_RESTORE_SOURCE_PATHS' => source_files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      app.restore_to_local_machine('latest')
+
+      assert_equal 'restored database', File.read(db)
+      assert_equal 'restored file', File.read(File.join(files, 'hello.txt'))
     end
   end
 


### PR DESCRIPTION
## Problem

When a SQLite database and file-backed (Active)storage are colocated under the same configured backup path, kamal-backup deliberately excludes the SQLite database, WAL, and shared-memory files from the file snapshot. Those files are backed up separately using SQLite’s consistent .backup mechanism.

Currently, restoration reverses that separation: it restores the SQLite database first, then replaces the entire colocated file-backup path. Wholesale replacement of that directory deletes the freshly restored database (because the file snapshot intentionally did not contain it).

## Fix

Restoring the file snapshot first and SQLite databases last avoids the issue entirely. It also ensures that a failed file restore cannot modify an otherwise successfully restored database. 

Local and production restores now retain SQLite databases stored alongside co-located file-backed Active Storage data. PostgreSQL and MySQL restores keep the same inputs and outputs.

## Checks

Test suite passes (226 runs, 834 assertions, 0 failures, 2 integration skips) and rubocop finds no offenses
