### PR TITLE
Harden backup and restore integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ accessories:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
     volumes:
-      - "chatwithwork_storage:/data/storage:ro"
+      - "chatwithwork_storage:/data/storage"
       - "chatwithwork_backup_state:/var/lib/kamal-backup"
 ```
 
-For SQLite databases stored on the mounted storage volume, omit `:ro` from that volume.
+The storage volume is writable so `restore production` can replace its contents safely without replacing the mount
+point. Writable access is also required for SQLite databases stored on that volume. For a backup-only accessory,
+you can append `:ro`; remove it and reboot the accessory before a production file restore.
 When the configured SQLite database file lives under a configured file backup path, `kamal-backup` excludes the raw database, WAL, and shared-memory files from the restic file snapshot automatically.
 
 Put the backup settings in `config/kamal-backup.yml`:

--- a/docs/_guide/configuration.md
+++ b/docs/_guide/configuration.md
@@ -124,12 +124,14 @@ accessories:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
     volumes:
-      - "chatwithwork_storage:/data/storage:ro"
+      - "chatwithwork_storage:/data/storage"
       - "chatwithwork_backup_state:/var/lib/kamal-backup"
 ```
 {: data-title="config/deploy.yml"}
 
 The `files:` line is what keeps non-secret backup settings out of environment variables. Kamal uploads `config/kamal-backup.yml` and mounts it read-only into the accessory.
+The storage volume is writable so production file restores and live SQLite WAL backups can work. For a backup-only
+accessory, append `:ro`; remove it and reboot the accessory before running `restore production`.
 
 ## Secrets
 

--- a/docs/_guide/getting-started.md
+++ b/docs/_guide/getting-started.md
@@ -85,14 +85,16 @@ accessories:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
     volumes:
-      - "chatwithwork_storage:/data/storage:ro"
+      - "chatwithwork_storage:/data/storage"
       - "chatwithwork_backup_state:/var/lib/kamal-backup"
 ```
 {: data-title="config/deploy.yml"}
 
 Kamal uploads `config/kamal-backup.yml` and mounts it read-only into the accessory. Secrets still stay in Kamal secrets.
 
-If your SQLite database lives on the mounted storage volume, omit `:ro` from that volume so SQLite can back up the live WAL database normally.
+The storage volume is writable so `restore production` can replace its contents without replacing the mount point.
+Writable access is also required when a live SQLite database is stored on that volume. For a backup-only accessory,
+you can append `:ro`; remove it and reboot the accessory before a production file restore.
 
 ## 4. Boot the accessory
 

--- a/docs/_guide/how-backups-work.md
+++ b/docs/_guide/how-backups-work.md
@@ -40,7 +40,8 @@ When a backup run starts, `kamal-backup` does five things:
 1. It validates the app name, restic repository, database settings, and file paths.
 2. It creates database backups using the database-native export tool:
    PostgreSQL uses `pg_dump`, MySQL/MariaDB use `mariadb-dump` or `mysqldump`, and SQLite uses `sqlite3 .backup`.
-3. It streams each database backup into restic and tags it with `type:database`, `database:<name>`, and `adapter:<adapter>`.
+3. It has restic run and capture each database export, then tags the snapshot with `type:database`,
+   `database:<name>`, and `adapter:<adapter>`. If the export command fails, restic does not create a snapshot.
 4. It runs one `restic backup` for the configured paths and tags that snapshot with `type:files`. Path-level excludes and automatic SQLite database/WAL/SHM excludes apply only to this file snapshot.
 5. It optionally prunes old snapshots and runs the same repository verification as `kamal-backup check`, depending on configuration.
 

--- a/docs/_guide/restore.md
+++ b/docs/_guide/restore.md
@@ -93,6 +93,10 @@ This path uses:
 - the accessory's current paths
 - the same restic repository the scheduled backups use
 
+The storage volume must be mounted read-write for a production file restore. The restore replaces the contents of
+an existing mounted directory while preserving the mount point itself, then restores databases. Restoring files
+first prevents a failed or read-only file restore from leaving the database at a different point in time.
+
 This is intentionally not a quiet operation. `restore production` is for real incident recovery.
 
 `restore production` does not accept `--yes` as a confirmation shortcut. Interactive use asks you to type the app name and `RESTORE PRODUCTION`. Automation must pass the explicit `--confirm-production-restore` flag.

--- a/docs/_reference/security.md
+++ b/docs/_reference/security.md
@@ -33,7 +33,9 @@ This is why the docs talk about database backups rather than raw database direct
 
 ## Active Storage backups
 
-File-backed Active Storage files are backed up from configured mounted paths with `restic backup`. In a Kamal accessory, mount the production storage volume read-only when possible so the backup container can read Active Storage files without being able to modify them.
+File-backed Active Storage files are backed up from configured mounted paths with `restic backup`. A backup-only
+accessory can mount the production storage volume read-only so the container cannot modify it. `restore production`
+requires that mount to be writable; remove `:ro` and reboot the accessory before restoring files.
 
 SQLite is the exception when the live database is on that storage volume. Rails SQLite apps commonly use WAL mode, and live WAL backups need normal read-write access to the database, WAL, and shared-memory files. For the normal SQLite setup, mount the storage volume read-write and point the SQLite database `path` at the live database. If the backup accessory must have no write access to app storage, back up a writer-created WAL-less snapshot instead.
 

--- a/examples/kamal-accessory.yml
+++ b/examples/kamal-accessory.yml
@@ -11,5 +11,5 @@ accessories:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
     volumes:
-      - "chatwithwork_storage:/data/storage:ro"
+      - "chatwithwork_storage:/data/storage"
       - "chatwithwork_backup_state:/var/lib/kamal-backup"

--- a/lib/kamal_backup/app.rb
+++ b/lib/kamal_backup/app.rb
@@ -374,9 +374,11 @@ module KamalBackup
     end
 
     def perform_replacement_file_restore(snapshot, production_source:)
+      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'], required: false)
+      return nil unless resolved_snapshot
+
       source_paths = production_source ? config.backup_paths : config.local_restore_source_paths
       target_paths = config.backup_paths
-      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'])
       Dir.mktmpdir('kamal-backup-restore-') do |stage_dir|
         restic.restore_snapshot(resolved_snapshot, stage_dir)
         replace_target_paths(stage_dir, source_paths: source_paths, target_paths: target_paths)
@@ -411,7 +413,9 @@ module KamalBackup
     end
 
     def perform_file_restore(snapshot, target:)
-      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'])
+      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'], required: false)
+      return nil unless resolved_snapshot
+
       validated_target = config.validate_file_restore_target(target)
       restic.restore_snapshot(resolved_snapshot, validated_target)
 
@@ -471,11 +475,17 @@ module KamalBackup
                      end
     end
 
-    def resolve_snapshot(argument, tags:)
+    # Database-only configs never create a type:files snapshot, so file restores
+    # resolve with required: false and skip when nothing was backed up.
+    def resolve_snapshot(argument, tags:, required: true)
       if argument == 'latest'
         snapshot = restic.latest_snapshot(tags: tags)
 
-        raise ConfigurationError, "no restic snapshot found for #{tags.join(', ')}" unless snapshot
+        if snapshot.nil?
+          raise ConfigurationError, "no restic snapshot found for #{tags.join(', ')}" if required
+
+          return nil
+        end
 
         snapshot['short_id'] || snapshot['id']
       else

--- a/lib/kamal_backup/app.rb
+++ b/lib/kamal_backup/app.rb
@@ -58,8 +58,8 @@ module KamalBackup
 
       build_restore_result('local', snapshot) do |result|
         databases.each { |adapter| validate_local_machine_database_target(adapter) }
-        result[:databases] = perform_database_restores_to_current(snapshot)
         result[:files] = perform_replacement_file_restore(snapshot, production_source: false)
+        result[:databases] = perform_database_restores_to_current(snapshot)
       end
     end
 
@@ -67,8 +67,8 @@ module KamalBackup
       validate_production_restore
 
       build_restore_result('production', snapshot) do |result|
-        result[:databases] = perform_database_restores_to_current(snapshot)
         result[:files] = perform_replacement_file_restore(snapshot, production_source: true)
+        result[:databases] = perform_database_restores_to_current(snapshot)
       end
     end
 

--- a/lib/kamal_backup/app.rb
+++ b/lib/kamal_backup/app.rb
@@ -77,8 +77,8 @@ module KamalBackup
 
       run_drill('local', snapshot, check_command: check_command) do |result|
         databases.each { |adapter| validate_local_machine_database_target(adapter) }
-        result[:databases] = perform_database_restores_to_current(snapshot)
         result[:files] = perform_replacement_file_restore(snapshot, production_source: false)
+        result[:databases] = perform_database_restores_to_current(snapshot)
       end
     end
 
@@ -87,6 +87,7 @@ module KamalBackup
       validate_production_drill(file_target, database_name, sqlite_path)
 
       run_drill('production', snapshot, check_command: check_command) do |result|
+        result[:files] = perform_file_restore(snapshot, target: file_target)
         result[:databases] = databases.map do |adapter|
           perform_database_restore_to_scratch(
             snapshot,
@@ -95,7 +96,6 @@ module KamalBackup
             sqlite_path: sqlite_path
           )
         end
-        result[:files] = perform_file_restore(snapshot, target: file_target)
       end
     end
 
@@ -374,11 +374,11 @@ module KamalBackup
     end
 
     def perform_replacement_file_restore(snapshot, production_source:)
-      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'], required: false)
-      return nil unless resolved_snapshot
+      return nil if config.backup_paths.empty?
 
       source_paths = production_source ? config.backup_paths : config.local_restore_source_paths
       target_paths = config.backup_paths
+      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'])
       Dir.mktmpdir('kamal-backup-restore-') do |stage_dir|
         restic.restore_snapshot(resolved_snapshot, stage_dir)
         replace_target_paths(stage_dir, source_paths: source_paths, target_paths: target_paths)
@@ -392,8 +392,20 @@ module KamalBackup
     end
 
     def replace_target_paths(stage_dir, source_paths:, target_paths:)
-      source_paths.zip(target_paths).each do |source_path, target_path|
+      path_pairs = source_paths.zip(target_paths)
+      validate_replacement_paths(stage_dir, path_pairs)
+
+      path_pairs.each do |source_path, target_path|
         replace_target_path(stage_dir, source_path, target_path)
+      end
+    end
+
+    def validate_replacement_paths(stage_dir, path_pairs)
+      path_pairs.each do |source_path, target_path|
+        source = staged_backup_path(stage_dir, source_path)
+        raise ConfigurationError, "restored file snapshot is missing #{source_path}" unless File.exist?(source)
+
+        ensure_writable_restore_target(target_path)
       end
     end
 
@@ -403,9 +415,29 @@ module KamalBackup
 
       raise ConfigurationError, "restored file snapshot is missing #{source_path}" unless File.exist?(source)
 
-      FileUtils.rm_rf(target)
-      FileUtils.mkdir_p(File.dirname(target))
-      FileUtils.mv(source, target)
+      if File.directory?(source) && File.directory?(target) && !File.symlink?(target)
+        replace_directory_contents(source, target)
+      else
+        FileUtils.remove_entry(target) if File.exist?(target) || File.symlink?(target)
+        FileUtils.mkdir_p(File.dirname(target))
+        FileUtils.mv(source, target)
+      end
+    rescue Errno::EACCES, Errno::EPERM, Errno::EROFS => e
+      raise ConfigurationError, "cannot restore files to #{target}: target must be writable (#{e.message})"
+    end
+
+    def ensure_writable_restore_target(target_path)
+      target = File.expand_path(target_path)
+      return unless File.directory?(target) && !File.symlink?(target)
+
+      Dir.mktmpdir('.kamal-backup-write-test-', target) {}
+    rescue Errno::EACCES, Errno::EPERM, Errno::EROFS => e
+      raise ConfigurationError, "cannot restore files to #{target}: target must be writable (#{e.message})"
+    end
+
+    def replace_directory_contents(source, target)
+      Dir.children(target).each { |entry| FileUtils.remove_entry(File.join(target, entry)) }
+      Dir.children(source).each { |entry| FileUtils.mv(File.join(source, entry), target) }
     end
 
     def staged_backup_path(stage_dir, path)
@@ -413,9 +445,9 @@ module KamalBackup
     end
 
     def perform_file_restore(snapshot, target:)
-      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'], required: false)
-      return nil unless resolved_snapshot
+      return nil if config.backup_paths.empty?
 
+      resolved_snapshot = resolve_snapshot(snapshot, tags: ['type:files'])
       validated_target = config.validate_file_restore_target(target)
       restic.restore_snapshot(resolved_snapshot, validated_target)
 
@@ -440,7 +472,7 @@ module KamalBackup
     def validate_production_drill(file_target, database_name, sqlite_path)
       config.validate_restic
       config.validate_database_backup
-      config.validate_file_restore_target(file_target)
+      config.validate_file_restore_target(file_target) if config.backup_paths.any?
 
       databases.each do |adapter|
         case adapter.adapter_name
@@ -475,17 +507,11 @@ module KamalBackup
                      end
     end
 
-    # Database-only configs never create a type:files snapshot, so file restores
-    # resolve with required: false and skip when nothing was backed up.
-    def resolve_snapshot(argument, tags:, required: true)
+    def resolve_snapshot(argument, tags:)
       if argument == 'latest'
         snapshot = restic.latest_snapshot(tags: tags)
 
-        if snapshot.nil?
-          raise ConfigurationError, "no restic snapshot found for #{tags.join(', ')}" if required
-
-          return nil
-        end
+        raise ConfigurationError, "no restic snapshot found for #{tags.join(', ')}" unless snapshot
 
         snapshot['short_id'] || snapshot['id']
       else

--- a/lib/kamal_backup/cli/helpers.rb
+++ b/lib/kamal_backup/cli/helpers.rb
@@ -289,7 +289,7 @@ module KamalBackup
                   - AWS_ACCESS_KEY_ID
                   - AWS_SECRET_ACCESS_KEY
               volumes:
-                - "your_app_storage:/data/storage:ro"
+                - "your_app_storage:/data/storage"
                 - "your_app_backup_state:/var/lib/kamal-backup"
         YAML
       end

--- a/lib/kamal_backup/restic.rb
+++ b/lib/kamal_backup/restic.rb
@@ -28,13 +28,12 @@ module KamalBackup
     end
 
     def backup_stream(command, filename:, tags:)
-      restic_command = CommandSpec.new(
-        argv: %w[restic
-                 backup] + host_args + ['--stdin', '--stdin-filename', filename] + tag_args(common_tags + tags),
-        env: restic_env
-      )
       log("backing up stream as #{filename}")
-      pipe_commands(command, restic_command, producer_label: 'dump', consumer_label: 'restic backup')
+      run(
+        ['backup'] + host_args + ['--stdin-filename', filename] + tag_args(common_tags + tags) +
+          ['--stdin-from-command', '--'] + command.argv,
+        env: restic_env.merge(command.env)
+      )
     end
 
     def backup_file(path, filename:, tags:)
@@ -211,9 +210,9 @@ module KamalBackup
 
     private
 
-    def run(args, log_output: true)
+    def run(args, log_output: true, env: restic_env)
       Command.capture(
-        CommandSpec.new(argv: ['restic'] + args, env: restic_env),
+        CommandSpec.new(argv: ['restic'] + args, env: env),
         redactor: redactor,
         log_output: log_output
       )

--- a/lib/kamal_backup/scheduler.rb
+++ b/lib/kamal_backup/scheduler.rb
@@ -24,7 +24,7 @@ module KamalBackup
           @backup_block.call
           log("backup completed at #{Time.now.utc.iso8601}")
         rescue StandardError => e
-          warn("[kamal-backup] backup failed at #{Time.now.utc.iso8601}: #{e.class}: #{e.message}")
+          warn("ERROR [kamal-backup] backup failed at #{Time.now.utc.iso8601}: #{e.class}: #{e.message}")
         end
 
         sleep_interruptibly(@config.backup_schedule_seconds)
@@ -49,7 +49,7 @@ module KamalBackup
     end
 
     def log(message)
-      $stdout.puts("[kamal-backup] #{message}")
+      $stdout.puts("INFO [kamal-backup] #{message}")
     end
   end
 end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -489,6 +489,70 @@ class AppTest < Minitest::Test
     end
   end
 
+  def test_restore_to_production_replaces_a_configured_file
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_production.sqlite3')
+      file = File.join(dir, 'manifest.json')
+      File.write(db, '')
+      File.write(file, 'stale')
+
+      restic = FakeRestic.new
+      restic.stage_file('latest-files-snapshot', file, 'restored')
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => file
+        ),
+        restic: restic,
+        database: database
+      )
+
+      app.restore_to_production('latest')
+
+      assert_equal 'restored', File.read(file)
+      assert_equal 1, database.current_restore_calls.size
+    end
+  end
+
+  def test_file_restore_reports_an_unwritable_file_target
+    Dir.mktmpdir do |dir|
+      target = File.join(dir, 'manifest.json')
+      source_path = '/data/manifest.json'
+      stage_dir = File.join(dir, 'stage')
+      source = File.join(stage_dir, source_path.sub(%r{\A/+}, ''))
+      FileUtils.mkdir_p(File.dirname(source))
+      File.write(source, 'restored')
+      File.write(target, 'stale')
+      app = KamalBackup::App.new(env: base_env)
+
+      error = FileUtils.stub(:remove_entry, ->(*) { raise Errno::EROFS, target }) do
+        assert_raises(KamalBackup::ConfigurationError) do
+          app.send(:replace_target_path, stage_dir, source_path, target)
+        end
+      end
+
+      assert_includes error.message, 'target must be writable'
+    end
+  end
+
+  def test_file_restore_preflight_reports_an_unwritable_directory_target
+    Dir.mktmpdir do |dir|
+      target = File.join(dir, 'storage')
+      FileUtils.mkdir_p(target)
+      app = KamalBackup::App.new(env: base_env)
+
+      error = Dir.stub(:mktmpdir, ->(*) { raise Errno::EROFS, target }) do
+        assert_raises(KamalBackup::ConfigurationError) do
+          app.send(:ensure_writable_restore_target, target)
+        end
+      end
+
+      assert_includes error.message, 'target must be writable'
+    end
+  end
+
   def test_restore_to_production_preserves_sqlite_database_inside_file_backup_path
     Dir.mktmpdir do |dir|
       files = File.join(dir, 'storage')

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -437,7 +437,7 @@ class AppTest < Minitest::Test
 
       result = app.restore_to_local_machine('latest')
 
-      assert_equal [['type:database', 'database:app', 'adapter:sqlite'], ['type:files']], restic.latest_snapshot_calls
+      assert_equal [['type:files'], ['type:database', 'database:app', 'adapter:sqlite']], restic.latest_snapshot_calls
       assert_equal [{ snapshot: 'latest-database-snapshot', adapter: 'sqlite', database_name: 'app' }],
                    restic.database_file_calls
       assert_equal 1, database.current_restore_calls.size
@@ -484,6 +484,72 @@ class AppTest < Minitest::Test
       assert_equal 1, database.current_restore_calls.size
       assert_equal 'hello from production backup', File.read(File.join(files, 'hello.txt'))
       refute File.exist?(old_file)
+    end
+  end
+
+  def test_restore_to_production_preserves_sqlite_database_inside_file_backup_path
+    Dir.mktmpdir do |dir|
+      files = File.join(dir, 'storage')
+      db = File.join(files, 'app_production.sqlite3')
+      FileUtils.mkdir_p(files)
+      File.write(db, 'live')
+
+      restic = FakeRestic.new
+      restic.stage_file('latest-files-snapshot', File.join(files, 'hello.txt'), 'restored file')
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      database.define_singleton_method(:restore_to_current) do |_restic, _snapshot, _filename|
+        FileUtils.mkdir_p(File.dirname(db))
+        File.write(db, 'restored database')
+      end
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      app.restore_to_production('latest')
+
+      assert_equal 'restored database', File.read(db)
+      assert_equal 'restored file', File.read(File.join(files, 'hello.txt'))
+    end
+  end
+
+  def test_restore_to_local_machine_preserves_sqlite_database_inside_file_backup_path
+    Dir.mktmpdir do |dir|
+      source_files = '/data/storage'
+      files = File.join(dir, 'storage')
+      db = File.join(files, 'app_development.sqlite3')
+      FileUtils.mkdir_p(files)
+      File.write(db, 'live')
+
+      restic = FakeRestic.new
+      restic.stage_file('latest-files-snapshot', File.join(source_files, 'hello.txt'), 'restored file')
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      database.define_singleton_method(:restore_to_current) do |_restic, _snapshot, _filename|
+        FileUtils.mkdir_p(File.dirname(db))
+        File.write(db, 'restored database')
+      end
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files,
+          'LOCAL_RESTORE_SOURCE_PATHS' => source_files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      app.restore_to_local_machine('latest')
+
+      assert_equal 'restored database', File.read(db)
+      assert_equal 'restored file', File.read(File.join(files, 'hello.txt'))
     end
   end
 

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -54,7 +54,7 @@ class AppTest < Minitest::Test
 
       if tags.include?('type:database')
         { 'short_id' => @database_snapshot, 'time' => snapshot_time }
-      else
+      elsif @files_snapshot
         { 'short_id' => @files_snapshot, 'time' => snapshot_time }
       end
     end
@@ -550,6 +550,130 @@ class AppTest < Minitest::Test
 
       assert_equal 'restored database', File.read(db)
       assert_equal 'restored file', File.read(File.join(files, 'hello.txt'))
+    end
+  end
+
+  def test_restore_to_local_machine_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_development.sqlite3')
+      files = File.join(dir, 'storage')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.restore_to_local_machine('latest')
+
+      assert_equal 1, database.current_restore_calls.size
+      assert_equal 'latest-database-snapshot', database.current_restore_calls.first.fetch(:snapshot)
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
+      assert_equal 'restore_result', result.fetch(:kind)
+    end
+  end
+
+  def test_restore_to_production_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_production.sqlite3')
+      files = File.join(dir, 'storage')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.restore_to_production('latest')
+
+      assert_equal 1, database.current_restore_calls.size
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
+      assert_equal 'production', result.fetch(:scope)
+    end
+  end
+
+  def test_drill_on_local_machine_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_development.sqlite3')
+      files = File.join(dir, 'storage')
+      state = File.join(dir, 'state')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files,
+          'KAMAL_BACKUP_STATE_DIR' => state
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.drill_on_local_machine('latest')
+
+      assert_equal 'ok', result.fetch(:status)
+      assert_equal 1, database.current_restore_calls.size
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
+    end
+  end
+
+  def test_drill_on_production_skips_file_restore_for_database_only_backups
+    Dir.mktmpdir do |dir|
+      target = File.join(dir, 'restored-files')
+      state = File.join(dir, 'state')
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'postgres')
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'postgres',
+          'DATABASE_URL' => 'postgres://app@db/app_production',
+          'KAMAL_BACKUP_STATE_DIR' => state
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.drill_on_production(
+        'latest',
+        database_name: 'app_restore_20260711',
+        file_target: target
+      )
+
+      assert_equal 'ok', result.fetch(:status)
+      assert_equal 1, database.scratch_restore_calls.size
+      assert_empty restic.restore_snapshot_calls
+      assert_nil result.fetch(:files)
     end
   end
 

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -461,6 +461,7 @@ class AppTest < Minitest::Test
       File.write(db, '')
       FileUtils.mkdir_p(files)
       File.write(old_file, 'stale')
+      target_identity = [File.stat(files).dev, File.stat(files).ino]
 
       restic = FakeRestic.new
       restic.stage_file('latest-files-snapshot', File.join(files, 'hello.txt'), 'hello from production backup')
@@ -484,6 +485,7 @@ class AppTest < Minitest::Test
       assert_equal 1, database.current_restore_calls.size
       assert_equal 'hello from production backup', File.read(File.join(files, 'hello.txt'))
       refute File.exist?(old_file)
+      assert_equal target_identity, [File.stat(files).dev, File.stat(files).ino]
     end
   end
 
@@ -553,12 +555,49 @@ class AppTest < Minitest::Test
     end
   end
 
+  def test_drill_on_local_machine_preserves_sqlite_database_inside_file_backup_path
+    Dir.mktmpdir do |dir|
+      source_files = '/data/storage'
+      files = File.join(dir, 'storage')
+      db = File.join(files, 'app_development.sqlite3')
+      state = File.join(dir, 'state')
+      FileUtils.mkdir_p(files)
+      File.write(db, 'live')
+
+      restic = FakeRestic.new
+      restic.stage_file('latest-files-snapshot', File.join(source_files, 'hello.txt'), 'restored file')
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      database.define_singleton_method(:restore_to_current) do |_restic, _snapshot, _filename|
+        FileUtils.mkdir_p(File.dirname(db))
+        File.write(db, 'restored database')
+      end
+
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files,
+          'LOCAL_RESTORE_SOURCE_PATHS' => source_files,
+          'KAMAL_BACKUP_STATE_DIR' => state
+        ),
+        restic: restic,
+        database: database
+      )
+
+      result = app.drill_on_local_machine('latest')
+
+      assert_equal 'ok', result.fetch(:status)
+      assert_equal 'restored database', File.read(db)
+      assert_equal 'restored file', File.read(File.join(files, 'hello.txt'))
+      assert_equal [['type:files'], ['type:database', 'database:app', 'adapter:sqlite']],
+                   restic.latest_snapshot_calls
+    end
+  end
+
   def test_restore_to_local_machine_skips_file_restore_for_database_only_backups
     Dir.mktmpdir do |dir|
       db = File.join(dir, 'app_development.sqlite3')
-      files = File.join(dir, 'storage')
       File.write(db, '')
-      FileUtils.mkdir_p(files)
 
       restic = FakeRestic.new
       restic.files_snapshot = nil
@@ -568,7 +607,7 @@ class AppTest < Minitest::Test
         env: base_env(
           'DATABASE_ADAPTER' => 'sqlite',
           'SQLITE_DATABASE_PATH' => db,
-          'BACKUP_PATHS' => files
+          'BACKUP_PATHS' => ''
         ),
         restic: restic,
         database: database
@@ -581,15 +620,14 @@ class AppTest < Minitest::Test
       assert_empty restic.restore_snapshot_calls
       assert_nil result.fetch(:files)
       assert_equal 'restore_result', result.fetch(:kind)
+      assert_equal [['type:database', 'database:app', 'adapter:sqlite']], restic.latest_snapshot_calls
     end
   end
 
   def test_restore_to_production_skips_file_restore_for_database_only_backups
     Dir.mktmpdir do |dir|
       db = File.join(dir, 'app_production.sqlite3')
-      files = File.join(dir, 'storage')
       File.write(db, '')
-      FileUtils.mkdir_p(files)
 
       restic = FakeRestic.new
       restic.files_snapshot = nil
@@ -599,7 +637,7 @@ class AppTest < Minitest::Test
         env: base_env(
           'DATABASE_ADAPTER' => 'sqlite',
           'SQLITE_DATABASE_PATH' => db,
-          'BACKUP_PATHS' => files
+          'BACKUP_PATHS' => ''
         ),
         restic: restic,
         database: database
@@ -611,16 +649,15 @@ class AppTest < Minitest::Test
       assert_empty restic.restore_snapshot_calls
       assert_nil result.fetch(:files)
       assert_equal 'production', result.fetch(:scope)
+      assert_equal [['type:database', 'database:app', 'adapter:sqlite']], restic.latest_snapshot_calls
     end
   end
 
   def test_drill_on_local_machine_skips_file_restore_for_database_only_backups
     Dir.mktmpdir do |dir|
       db = File.join(dir, 'app_development.sqlite3')
-      files = File.join(dir, 'storage')
       state = File.join(dir, 'state')
       File.write(db, '')
-      FileUtils.mkdir_p(files)
 
       restic = FakeRestic.new
       restic.files_snapshot = nil
@@ -630,7 +667,7 @@ class AppTest < Minitest::Test
         env: base_env(
           'DATABASE_ADAPTER' => 'sqlite',
           'SQLITE_DATABASE_PATH' => db,
-          'BACKUP_PATHS' => files,
+          'BACKUP_PATHS' => '',
           'KAMAL_BACKUP_STATE_DIR' => state
         ),
         restic: restic,
@@ -643,6 +680,7 @@ class AppTest < Minitest::Test
       assert_equal 1, database.current_restore_calls.size
       assert_empty restic.restore_snapshot_calls
       assert_nil result.fetch(:files)
+      assert_equal [['type:database', 'database:app', 'adapter:sqlite']], restic.latest_snapshot_calls
     end
   end
 
@@ -658,6 +696,7 @@ class AppTest < Minitest::Test
         env: base_env(
           'DATABASE_ADAPTER' => 'postgres',
           'DATABASE_URL' => 'postgres://app@db/app_production',
+          'BACKUP_PATHS' => '',
           'KAMAL_BACKUP_STATE_DIR' => state
         ),
         restic: restic,
@@ -674,6 +713,36 @@ class AppTest < Minitest::Test
       assert_equal 1, database.scratch_restore_calls.size
       assert_empty restic.restore_snapshot_calls
       assert_nil result.fetch(:files)
+      assert_equal [['type:database', 'database:app', 'adapter:postgres']], restic.latest_snapshot_calls
+    end
+  end
+
+  def test_restore_to_production_rejects_a_missing_file_snapshot_before_restoring_the_database
+    Dir.mktmpdir do |dir|
+      db = File.join(dir, 'app_production.sqlite3')
+      files = File.join(dir, 'storage')
+      File.write(db, '')
+      FileUtils.mkdir_p(files)
+
+      restic = FakeRestic.new
+      restic.files_snapshot = nil
+      database = FakeDatabase.new(adapter_name: 'sqlite', current_target_identifier: db)
+      app = KamalBackup::App.new(
+        env: base_env(
+          'DATABASE_ADAPTER' => 'sqlite',
+          'SQLITE_DATABASE_PATH' => db,
+          'BACKUP_PATHS' => files
+        ),
+        restic: restic,
+        database: database
+      )
+
+      error = assert_raises(KamalBackup::ConfigurationError) do
+        app.restore_to_production('latest')
+      end
+
+      assert_includes error.message, 'no restic snapshot found for type:files'
+      assert_empty database.current_restore_calls
     end
   end
 

--- a/test/integration_sqlite_restic_test.rb
+++ b/test/integration_sqlite_restic_test.rb
@@ -78,4 +78,37 @@ class IntegrationSqliteResticTest < Minitest::Test
       assert_equal 'hello from files', File.read(File.join(files, 'hello.txt'))
     end
   end
+
+  def test_failed_database_dump_does_not_create_a_restic_snapshot
+    skip 'set KAMAL_BACKUP_RUN_INTEGRATION=1 to run restic integration tests' unless ENV['KAMAL_BACKUP_RUN_INTEGRATION'] == '1'
+    skip 'restic is required' unless system('which', 'restic', out: File::NULL)
+
+    Dir.mktmpdir do |dir|
+      config = KamalBackup::Config.new(
+        env: base_env(
+          'APP_NAME' => 'integration',
+          'BACKUP_PATHS' => '',
+          'RESTIC_REPOSITORY' => File.join(dir, 'repo'),
+          'RESTIC_PASSWORD' => 'integration-secret',
+          'RESTIC_INIT_IF_MISSING' => 'true'
+        )
+      )
+      restic = KamalBackup::Restic.new(config, redactor: KamalBackup::Redactor.new(env: config.env))
+      restic.ensure_repository
+      dump_command = KamalBackup::CommandSpec.new(
+        argv: ['sh', '-c', 'printf partial-data; echo dump-failed >&2; exit 3']
+      )
+
+      error = assert_raises(KamalBackup::CommandError) do
+        restic.backup_stream(
+          dump_command,
+          filename: 'databases/integration/app/mysql.sql',
+          tags: ['type:database', 'database:app', 'adapter:mysql']
+        )
+      end
+
+      assert_includes error.message, 'dump-failed'
+      assert_nil restic.latest_snapshot(tags: ['type:database', 'database:app', 'adapter:mysql'])
+    end
+  end
 end

--- a/test/restic_test.rb
+++ b/test/restic_test.rb
@@ -23,13 +23,14 @@ class ResticTest < Minitest::Test
     def log(_message); end
   end
 
-  class CapturingPipeRestic < KamalBackup::Restic
-    attr_reader :consumer_argv
+  class CapturingBackupRestic < KamalBackup::Restic
+    attr_reader :backup_args, :backup_env
 
     private
 
-    def pipe_commands(_producer, consumer, **)
-      @consumer_argv = consumer.argv
+    def run(args, env:, **)
+      @backup_args = args
+      @backup_env = env
       KamalBackup::CommandResult.new(stdout: '', stderr: '', status: 0)
     end
 
@@ -125,12 +126,20 @@ class ResticTest < Minitest::Test
       'SQLITE_DATABASE_PATH' => '/data/storage/production.sqlite3',
       'BACKUP_PATHS' => '/data/storage'
     ))
-    restic = CapturingPipeRestic.new(config, redactor: KamalBackup::Redactor.new(env: {}))
-    dump_command = KamalBackup::CommandSpec.new(argv: ['sqlite3', '/data/storage/production.sqlite3', '.dump'], env: {})
+    restic = CapturingBackupRestic.new(config, redactor: KamalBackup::Redactor.new(env: {}))
+    dump_command = KamalBackup::CommandSpec.new(
+      argv: ['sqlite3', '/data/storage/production.sqlite3', '.dump'],
+      env: { 'DATABASE_SECRET' => 'secret' }
+    )
 
     restic.backup_stream(dump_command, filename: 'databases/demo/app/sqlite.sqlite3', tags: ['type:database'])
 
-    refute_includes restic.consumer_argv, '--exclude'
+    refute_includes restic.backup_args, '--exclude'
+    assert_includes restic.backup_args, '--stdin-from-command'
+    delimiter = restic.backup_args.index('--')
+    assert_equal dump_command.argv, restic.backup_args.drop(delimiter + 1)
+    assert_equal 'secret', restic.backup_env.fetch('DATABASE_SECRET')
+    assert_equal 'restic-secret', restic.backup_env.fetch('RESTIC_PASSWORD')
   end
 
   def test_backup_file_reports_restic_stderr_when_stdin_pipe_closes

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -32,9 +32,9 @@ class SchedulerTest < Minitest::Test
     out, _err = with_restored_traps { capture_io { Timeout.timeout(10) { scheduler.run } } }
 
     assert_equal 2, calls
-    assert_includes out, 'backup started at'
-    assert_includes out, 'backup completed at'
-    assert_includes out, 'scheduler stopped at'
+    assert_includes out, 'INFO [kamal-backup] backup started at'
+    assert_includes out, 'INFO [kamal-backup] backup completed at'
+    assert_includes out, 'INFO [kamal-backup] scheduler stopped at'
   end
 
   def test_run_warns_and_keeps_running_when_backup_raises
@@ -49,7 +49,7 @@ class SchedulerTest < Minitest::Test
     out, err = with_restored_traps { capture_io { Timeout.timeout(10) { scheduler.run } } }
 
     assert_equal 2, calls
-    assert_includes err, 'backup failed at'
+    assert_includes err, 'ERROR [kamal-backup] backup failed at'
     assert_includes err, 'RuntimeError: boom'
     assert_includes out, 'backup completed at'
   end


### PR DESCRIPTION
## Summary

- preserve the contributor commits from #10 and #12, then tighten database-only detection so a configured-but-missing file snapshot still fails safely
- restore files before databases in restores and drills, preserving colocated SQLite databases
- replace the contents of mounted directories without replacing the mount point, and document that production file restores require a writable mount
- use `restic backup --stdin-from-command` so failed PostgreSQL/MySQL dump commands cannot leave a partial snapshot eligible as the latest backup
- add explicit `INFO`/`ERROR` scheduler log levels

Closes #14
Closes #15

## Validation

- `KAMAL_BACKUP_RUN_INTEGRATION=1 bin/test` — 233 runs, 882 assertions, 0 failures, 0 errors
- `bundle exec rubocop` — 42 files, no offenses
- docs Jekyll build succeeds

The integration suite includes a real restic reproduction proving that a dump command which emits partial data and exits nonzero leaves no database snapshot.